### PR TITLE
Fix "Not git repository" error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,8 +60,11 @@ class GitExclude {
     }
 
     private getGitPath() : string {
-        var path = this.runCommand("git rev-parse --git-dir");
-        return path.trim();
+        var gitPath = this.runCommand("git rev-parse --git-dir");
+        if (gitPath) {
+            gitPath = path.resolve(vscode.workspace.rootPath, gitPath)
+        }
+        return gitPath.trim();
     }
     
 


### PR DESCRIPTION
The path `git rev-parse` returns is relative (".git") when at the project root.

This resulted in existence being checked against the cwd of the running vscode host instead of the project's working directory.